### PR TITLE
モデル一式の追加

### DIFF
--- a/app/models/application_record 2.rb
+++ b/app/models/application_record 2.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,0 +1,3 @@
+class Brand < ApplicationRecord
+  has_many :items
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,4 @@
+class Category < ApplicationRecord
+  has_many :items
+  has_ancestry
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -1,0 +1,3 @@
+class CreditCard < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -1,0 +1,3 @@
+class Evaluation < ActiveHash::Base
+  # activehashモデルです。中身をここに入れる必要があります。
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,4 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,22 @@
+class Item < ApplicationRecord
+  # belongs_to user, foreign_key: 'user_id'
+  belongs_to :category
+  has_many :comments, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  has_many :todo_lists
+  has_many :seller_items, foreign_key: "seller_id", class_name: "Item"
+  has_many :buyer_items, foreign_key: "buyer_id", class_name: "Item"
+  has_many :user_evaluations
+  has_one :point
+  has_one :profile, dependent: :destroy
+  has_one :sns_authentication, dependent: :destroy
+  has_one :sending_destination, dependent: :destroy
+  has_one :credit_card, dependent: :destroy
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :size
+  belongs_to_active_hash :item_condition
+  belongs_to_active_hash :postage_payer
+  belongs_to_active_hash :postage_type
+  belongs_to_active_hash :preparation_day
+end

--- a/app/models/item_condition.rb
+++ b/app/models/item_condition.rb
@@ -1,0 +1,12 @@
+class ItemCondition < ActiveHash::Base
+  self.data = [
+    {id: 1, item_condition: '新品、未使用'}, {id: 2, item_condition: '未使用に近い'}, {id: 3, item_condition: '目立った傷や汚れなし'},
+    {id: 4, item_condition: 'やや傷や汚れあり'}, {id: 5, item_condition: '傷や汚れあり'}
+]
+end
+
+# 新品、未使用：購入してからあまり時間が経っておらず、一度も使用していない
+# 未使用に近い：数回しか使用しておらず、傷や汚れがない
+# 目立った傷や汚れなし：よく見ないとわからない程度の傷や汚れがある
+# やや傷や汚れあり：中古品とわかる程度の傷や汚れがある
+# 傷や汚れあり：誰がみてもわかるような大きな傷や汚れがある

--- a/app/models/item_img.rb
+++ b/app/models/item_img.rb
@@ -1,0 +1,3 @@
+class ItemImg < ApplicationRecord
+  belongs_to :item
+end

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -1,0 +1,3 @@
+class Point < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/postage_payer.rb
+++ b/app/models/postage_payer.rb
@@ -1,0 +1,5 @@
+class PostagePayer < ActiveHash::Base
+  self.data = [
+    {id: 1, postagepayer: '送料込み(出品者負担)'}, {id: 2, postagepayer: '着払い(購入者負担)'}
+]
+end

--- a/app/models/postage_type.rb
+++ b/app/models/postage_type.rb
@@ -1,0 +1,8 @@
+class PostageType < ActiveHash::Base
+  self.data = [
+    {id: 1, postage_type: '小型サイズ - ネコポス（らくらくメルカリ便）
+    '}, {id: 2, postage_type: '小型サイズ（A4）- ゆうパケット（ゆうゆうメルカリ便）'}, {id: 3, postage_type: 'ゆうメール（着払いあり）'},
+    {id: 4, postage_type: 'ゆうパケット'}, {id: 5, postage_type: 'レターパック'}, {id: 6, postage_type: '普通郵便（定形、定形外）'},
+    {id: 7, postage_type: 'クリックポスト'}, {id: 8, postage_type: '小〜中型サイズ - 宅急便コンパクト（らくらくメルカリ便）'}
+]
+end

--- a/app/models/preparation_day.rb
+++ b/app/models/preparation_day.rb
@@ -1,0 +1,6 @@
+class PreparationDay < ActiveHash::Base
+  self.data = [
+    {id: 1, preparation_day_preparation_day_name: '１日〜２日'}, {id: 2, preparation_day_name: '２日〜３日'}, {id: 3, preparation_day_name: '３日〜４日'},
+    {id: 4, preparation_day_name: '４日〜５日'}, {id: 5, preparation_day_name: '５日〜６日'}, {id: 6, preparation_day_name: '〜７日'}
+]
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,3 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/sending_destination.rb
+++ b/app/models/sending_destination.rb
@@ -1,0 +1,3 @@
+class SendingDestination < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/size.rb
+++ b/app/models/size.rb
@@ -1,0 +1,7 @@
+class Size < ActiveHash::Base
+  self.data = [
+    {id: 1, name: 'XXS'}, {id: 2, name: 'XS(SS)'}, {id: 3, name: 'S'},
+    {id: 4, name: 'S'}, {id: 5, name: 'L'}, {id: 6, name: 'XL(LL)'},
+    {id: 7, name: '2XL(3L)'}, {id: 8, name: '3XL(4L)'}
+]
+end

--- a/app/models/sns_authentication.rb
+++ b/app/models/sns_authentication.rb
@@ -1,0 +1,3 @@
+class SnsAuthentication < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/todo_list.rb
+++ b/app/models/todo_list.rb
@@ -1,0 +1,3 @@
+class TodoList < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user_evaluation.rb
+++ b/app/models/user_evaluation.rb
@@ -1,0 +1,4 @@
+class UserEvaluation < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end


### PR DESCRIPTION
userモデル以外の全てのモデルを追加します。
migrationfileについては、別ブランチで追加予定です。
user
to_do_list
point
profile
sns_authentication
sending_destinations
credit_cardsitems
user_evaluations
中間テーブル(2つ)
comments
favorites
item_images
brands
categories
その他アクティブハッシュモデルを５つ追加