### PR TITLE
２つのマイグレーションファイルを追加します。（items,item_imgs）

### DIFF
--- a/db/migrate/20200422154827_create_items.rb
+++ b/db/migrate/20200422154827_create_items.rb
@@ -1,0 +1,26 @@
+class CreateItems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :items do |t|
+      t.string :name,null:false
+      t.text :introduction, null: false
+      t.integer :price,null: false
+      t.string :size_name
+      t.integer :size_id, null: false
+      t.string :item_condition
+      t.integer :item_condition_id, null: false
+      t.string :postage_payer
+      t.integer :postage_payer_id, null: false
+      t.string :preparation_day_name
+      t.integer :preparation_day_id, null: false
+      t.string :postage_type
+      t.integer :postage_type_id, null: false
+      #t.references :brand , foreign_key: true
+      t.integer :prefecture_code , null: false
+      #t.references :item_img , null: false, foreign_key: true
+      t.integer :trading_status, default: 0, null: false, limit: 1
+      t.references :user, null: false, foreign_key: true
+      t.timestamp :deal_closed_date
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200423025329_create_item_imgs.rb
+++ b/db/migrate/20200423025329_create_item_imgs.rb
@@ -1,0 +1,9 @@
+class CreateItemImgs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :item_imgs do |t|
+      t.string :url, null: false
+      t.references :item,null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
# What
20200422154827_create_items.rb
20200423025329_create_item_imgs.rb

外部キーの関係で先にitemsテーブルからmigrateしてください。
item_imgsから行うとエラーになることが確認されています。（外部キー設定のため）

# Why
本番環境で必要な画像保存先であるS3の作成に必要なため。
他のmigration-fileについては別ブランチ及び別コミットで申請予定です。
