### PR TITLE
商品出品ページの画像取り込み機能の修正

### DIFF
--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -26,16 +26,11 @@
               .exhibit__main__itemProfile__inputForm__sellImage__upload__box
                 .prev-content
                 .label-content
-                  %label{for: "item_item_images_attributes_0_image", class: "label-box", id: "label-box--0"}
+                  = f.label :item_imgs, class: "label-box", id: "label-box--0" do
                     %pre.label-box__text-visible クリックしてファイルをアップロード
                 .hidden-content
-                  = f.fields_for :item_imgs do |i|
-                    = i.file_field :url, class: "hidden-field"
-                    %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][1][image]", id: "item_item_images_attributes_1_image" }
-                    %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][2][image]", id: "item_item_images_attributes_2_image" }
-                    %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][3][image]", id: "item_item_images_attributes_3_image" }
-                    %input{class:"hidden-field", type: "file", name: "item[item_images_attributes][4][image]", id: "item_item_images_attributes_4_image" }
-                    
+                  = f.file_field :item_imgs, class: "hidden-field", multiple: true do
+                    商品画像
           .exhibit__main__itemProfile__inputForm__sellGoods
             .exhibit__main__itemProfile__inputForm__sellGoods__name
               .notation


### PR DESCRIPTION
# What
商品出品画像の取り込み機能の修正。
「クリックしてファイルをアップロード」
をクリックしても画像の選択ができなかたったのでそこで取り込める様に修正しました。
「type file」のメソッドのhamlの機能がうまく働いていなかった部分を修正しました。
# Why
画像出品機能を実装するにあたり、画像の投稿機能は必須条件であったため。