### PR TITLE
ローカルと本番環境で画像の保存先を分ける

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -3,6 +3,12 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
 
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
+
   # Choose what kind of storage to use for this uploader:
   # storage :file
   storage :fog

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,16 +1,19 @@
+require 'carrierwave/storage/abstract'
 require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  config.storage = :fog
-  config.fog_provider = 'fog/aws'
-  config.fog_credentials = {
-    provider: 'AWS',
-    aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-    aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-    region: 'ap-northeast-1'
-  }
-
+  if Rails.env.development? || Rails.env.test?
+    config.storage = :file
+  else
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1'
+    }
   config.fog_directory  = 'kenzobucket'
   config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/kenzobucket'
 end


### PR DESCRIPTION
# what
carrierwave.rb及びimage_uploader.rbにテスト環境＆開発環境時と本番環境でのデータ保存先を変更するコードを追記。

# why 
現状ではデプロイ担当者以外のローカルでは画像を保存できなくなっており、
ローカルでは環境変数が設定されておらず、S3へアクセスできない。
画像の保存先をローカルではアプリ内(uploadsフォルダ)、本番環境ではS3と条件分岐する必要があるため。