### PR TITLE
【サーバサイド】カテゴリ機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+
   def index
     @parents = Category.where(ancestry: nil)
   end
@@ -22,6 +23,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   def set_parents
     @parents = Category.where(ancestry: nil)
   end
@@ -38,6 +43,5 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :introduction, :category_id, :brand_id, :size_id, :postage_type_id, :item_condition_id, :postage_payer_id, :prefecture_id, :preparation_day_id, :price, :seller_id, :buyer_id, item_imgs_attributes: [:url])
   end
-
   
 end

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,0 +1,34 @@
+- if item.buyer_id.nil?
+  .pickup-container__product-box__product-lists__product-list
+    = link_to item_path(item), data:{"turbolinks" => false}, class: "line" do
+      .pickup-container__product-box__product-lists__product-list__img
+        = image_tag item.first_image.url.url, class: "img_k"
+      .body
+        .body__name
+          = item.name
+        %ul.body__details
+          %li.body__details__price
+            = item.price
+            円
+          %li.body__details__star
+            ★0
+        .body__tax
+          (税込)
+- else
+  .pickup-container__product-box__product-lists__product-list
+    = link_to item_path(item), data:{"turbolinks" => false}, class: "line" do
+      .pickup-container__product-box__product-lists__product-list__img
+        = image_tag item.first_image.image.url, class: "img_k"
+      .sold-cover
+      %p.sold sold
+      .body
+        .body__name
+          = item.name
+        %ul.body__details
+          %li.body__details__price
+            = item.price
+            円
+          %li.body__details__star
+            ★0
+        .body__tax
+          (税込)

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -154,8 +154,9 @@
           = link_to "items/new" do
             %h3.title 新規投稿商品
         .pickup-container__box__lists
+          -# = render @items
           .pickup-container__box__lists__list
-            = link_to "/products/3" do
+            = link_to "/items/3" do
               %figure.productList--img
                 %img.productList--img__img{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"}/
               .productList--body
@@ -168,11 +169,11 @@
                       0
                   .productList--body__details__tax (税込)
           .pickup-container__box__lists__list2
-            = link_to "/products/2" do
+            = link_to "/items/4" do
               %figure.productList--img
                 %img.productList--img__img{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"}/
               .productList--body
-                %h3.name product2
+                %h3.name product4
                 .productList--body__details
                   %ul.productList--body__details__detail
                     %li 20000円
@@ -181,11 +182,11 @@
                       0
                   .productList--body__details__tax (税込)
           .pickup-container__box__lists__list3
-            = link_to "/products/1" do
+            = link_to "/items/5" do
               %figure.productList--img
                 %img.productList--img__img{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/7/a001.png"}/
               .productList--body
-                %h3.name product1
+                %h3.name product5
                 .productList--body__details
                   %ul.productList--body__details__detail
                     %li 10000円

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -7,13 +7,13 @@
         .container__item-details__main__images__display
           画像
           %ul.container__item-details__main__images__display__up
-            -# - @item.item_imgs.each do |image| みたいな感じで表示せる
+            - @item.item_imgs.each do |image|
               %li.container__item-details__main__images__display__up__slide-image
-                -# = image_tag image.image_url, size: "300x300"　JSでサムネイルにカーソルがホバーしたときにスライドして表示させる　
+                = image_tag image.url.url, size: "300x300"
           %ul.container__item-details__main__images__display__down
-            -# "- @item.item_imgs.each do |image| みたいな感じで表示？
+            - @item.item_imgs.each do |image|
               %li.container__item-details__main__images__display__down__thumbnail-image
-                -# = image_tag image.image_url, size: "60x60"　下段のサムネ
+                = image_tag image.url.url, size: "60x60"
       %table.container__item-details__main__detail
         %tbody
           %tr
@@ -94,7 +94,7 @@
 
         
       %span.container__item-details__price__tax
-        (税込)
+        円 (税込)
       %span.container__item-details__price__delivery-fee
         送料込み
     .container__item-details__message


### PR DESCRIPTION
# What
商品カテゴリ機能実装
商品詳細ページで商品確認機能ができる様に実装
なお、ancestryを使用したカテゴリー機能については、以前に実装しており、今回は表示のみとなります。

# why
本機能には本アプリの根幹となる昨日で必須のため。ユーザーがより快適に利用する上では必須の機能であるため。

〈商品詳細ページ〉
https://gyazo.com/610901204de14669bf64aad24e559dae
https://gyazo.com/cfa5447f87fb12e8c112b7c45e0df130

〈商品が登録されているSequel Pro内〉
https://gyazo.com/90a18ca70c41c77ab213a909dbf5aad4
https://gyazo.com/47452c97fd4962ccafd04564b7c20fe9
https://gyazo.com/8a9db0da821f0861ae429ecd82929334

〈Categoryモデルの追加と実装〉
https://github.com/oznekpark/freemarket_sample_73j/blob/master/app/models/category.rb

〈ItemモデルでのCategoryについての記述〉
https://github.com/oznekpark/freemarket_sample_73j/blob/master/app/models/item.rb

〈ancestryの内容になるseeds.rbの情報の追加〉
https://github.com/oznekpark/freemarket_sample_73j/blob/master/db/seeds.rb
（※この際に、rake db:seed　コマンドにてDB側に情報を追記し、呼び出せる様にした）

〈gemの追加〉
https://github.com/oznekpark/freemarket_sample_73j/blob/master/Gemfile
（※ancestryはgemを用いて行うため、７９行目にgemを追加し、bundle installしている）

〈items.controllerに記述を追記〉
https://github.com/oznekpark/freemarket_sample_73j/blob/master/app/controllers/items_controller.rb
（※２５行目から３５行目にancestryのメソッドを呼び出せる様に記述を追記。）

〈routes.rbにルーティングの追記〉
https://github.com/oznekpark/freemarket_sample_73j/blob/master/config/routes.rb
（※１５行目と１６行目を追記。correctionでアクションを指定し、指示できる様に編集した）

〈jsが使える様に記述の追記〉
https://github.com/oznekpark/freemarket_sample_73j/blob/master/app/assets/javascripts/application.js
（※１４行目にjQueryが呼び出せる様に追記。）

〈jsファイルの追加〉
https://github.com/oznekpark/freemarket_sample_73j/blob/master/app/assets/javascripts/category.js

〈jbuilderファイルの追加〉
https://github.com/oznekpark/freemarket_sample_73j/blob/master/app/views/items/get_category_children.json.jbuilder
https://github.com/oznekpark/freemarket_sample_73j/blob/master/app/views/items/get_category_grandchildren.json.jbuilder


前に、手探りで行っていたこともあり、順番が前後してしまいました。
ここで一旦辻褄を合わせる様な形でコミットとなってしまい、わかりづらくなってしまいました。




