### PR TITLE
商品削除

### DIFF
--- a/app/assets/stylesheets/_item_new.scss
+++ b/app/assets/stylesheets/_item_new.scss
@@ -40,6 +40,8 @@
               flex-wrap: wrap;
               .prev-content {
                 display: flex;
+                position: relative;
+                height: 180px;
                 .preview-box {
                   height: 162px;
                   width: 112px;
@@ -48,30 +50,34 @@
                     height: 112px;
                     width: 100%;
                     img{
-                      width: 112px;
-                      height: 112px;
+                      width: 120px;
+                      height: 180px;
                     }
                   }
                   .lower-box {
                     display: flex;
                     text-align: center;
+                    position: absolute;
+                    bottom: 0;
+                    cursor: pointer;
                     .update-box {
                       color: #00b0ff;
                       width: 50%;
-                      height: 50px;
-                      line-height: 50px;
+                      height: 20px;
+                      line-height: 20px;
                       border: 1px solid #eee;
                       background: #f5f5f5;
                       cursor: pointer;
+                      margin-right: 60px;
                     }
                     .delete-box {
                       color: #00b0ff;
                       width: 50%;
-                      height: 50px;
-                      line-height: 50px;
+                      height: 20px;
+                      line-height: 20px;
                       border: 1px solid #eee;
                       background: #f5f5f5;
-                      cursor: pointer;
+                  
                     }
                   }
                 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,12 @@
 class ItemsController < ApplicationController
+  
 
   def index
     @parents = Category.where(ancestry: nil)
+    @items = Item.includes(:item_imgs).order("created_at DESC")
   end
 
-  def item_show
-  end
+  
 
   def new
     @item = Item.new
@@ -27,6 +28,17 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+  if @item.seller_id == current_user.id
+    if @item.destroy
+      redirect_to root_path
+    else
+      render "items/show"
+    end
+  end
+end
+
   def set_parents
     @parents = Category.where(ancestry: nil)
   end
@@ -43,5 +55,7 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :introduction, :category_id, :brand_id, :size_id, :postage_type_id, :item_condition_id, :postage_payer_id, :prefecture_id, :preparation_day_id, :price, :seller_id, :buyer_id, item_imgs_attributes: [:url])
   end
+  
+
   
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  
+  before_action :set_item, only:[:show,:destroy]
 
   def index
     @parents = Category.where(ancestry: nil)
@@ -25,19 +25,16 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
+    
   end
 
   def destroy
-    @item = Item.find(params[:id])
-  if @item.seller_id == current_user.id
-    if @item.destroy
+    if @item.seller_id == current_user.id && @item.destroy
       redirect_to root_path
     else
       render "items/show"
     end
   end
-end
 
   def set_parents
     @parents = Category.where(ancestry: nil)
@@ -57,5 +54,8 @@ end
   end
   
 
+  def set_item
+    @item = Item.find(params[:id])
+  end
   
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,7 +5,6 @@
     .container__item-details__main
       .container__item-details__main__images
         .container__item-details__main__images__display
-          画像
           %ul.container__item-details__main__images__display__up
             - @item.item_imgs.each do |image|
               %li.container__item-details__main__images__display__up__slide-image

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -9,7 +9,7 @@
           %ul.container__item-details__main__images__display__up
             - @item.item_imgs.each do |image|
               %li.container__item-details__main__images__display__up__slide-image
-                = image_tag image.url.url, size: "300x300"
+                = image_tag image.url.url, size: "280x400"
           %ul.container__item-details__main__images__display__down
             - @item.item_imgs.each do |image|
               %li.container__item-details__main__images__display__down__thumbnail-image
@@ -118,7 +118,13 @@
           %i.far.fa-flag
           %span
             不適切な商品の報告
-
+        - if @item.buyer_id != nil && current_user.id == @item.seller_id
+          .sellerSelect
+            = link_to '商品の削除', item_path(@item.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class: 'seller__delete'
+        - elsif user_signed_in? && current_user.id == @item.seller_id
+          .sellerSelect
+            = link_to '商品の編集', edit_item_path(@item.id), data:{"turbolinks" => false}, class: 'seller__edit'
+            = link_to '商品の削除', item_path(@item.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class: 'seller__delete'
       .container__item-details__buttons__right
         = link_to "" do
           %i.fas.fa-lock

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,6 @@ Rails.application.routes.draw do
   # スプリントレビューのためにitem_showを一時的に設定しています
   resources :items do
     collection do
-      get 'item_show'
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
     end


### PR DESCRIPTION
# what
出品した商品を、出品したユーザーのみが削除できる様に実装した。

# why
出品した商品を取り下げたり削除する機能はサービスの根幹を担う機能となり、ユーザーの使いやすさに直結するため必要不可欠であるため。

※商品の情報を削除することができるようになっている。商品情報を削除できるのは、商品を投稿したユーザーだけである。

〈他ユーザーが画面をみた場合〉
https://gyazo.com/e410c76e5eef96af9ff9412cd27d11b4

〈初品出品者が商品画面をみた場合〉
https://gyazo.com/0da5bff7e7aac676c0099e623bb6abf3

〈第三者（ログアウトしているユーザー）がみた場合〉
https://gyazo.com/e8be21036977b2b78bf0b0eaa91a4107

〈削除する前のDBの様子〉
（DB）
https://gyazo.com/b87da8e42d80853ca00290b7837d4d68
（削除対象のid:8のビューの様子）
https://gyazo.com/55c1d92ca3abb77bb8f5c7fbd2c3e29e
https://gyazo.com/bf2586bba690b3fbf3a2734b0c62d133

〈id:8のデータの削除後のDB〉
https://gyazo.com/1678f697940063be50e35fb80ffa8381