### PR TITLE
【サーバサイド】商品詳細表示

### DIFF
--- a/app/assets/stylesheets/_item.scss
+++ b/app/assets/stylesheets/_item.scss
@@ -1,0 +1,48 @@
+.pickup-container__product-box__product-lists {
+  width: 960px;
+  margin: 0 auto;
+  margin-top: 26px;
+  margin-bottom: 26px;
+  display: flex;
+  flex-wrap: wrap;
+  &__product-list {
+    .line {
+      background-color: #fff;
+      display: inline-block;
+      text-decoration: none;
+      color: #333;
+      margin :0 10px 20px 10px;
+      position: relative;
+      img {
+        width: 250px;
+        height: 320px;
+        background-color: white;
+        position: relative;
+        
+      }
+      .body {
+        padding: 16px;
+        background-color: white;
+        color: black;
+        height: 90px;
+        &__name {
+          font-size: 16px;
+          width: 150px;
+          overflow: hidden;
+        }
+        &__details {
+          display: flex;
+          justify-content: space-between;
+          &__star {
+            font-size: inherit;
+            text-rendering: auto;
+          }
+        }
+        &__tax {
+          font-size: 10px;
+          text-align: left;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -34,8 +34,10 @@
           min-height: 375px;
           position: relative;
           overflow: hidden;
+          padding-top: 10px;
           &__up{
             display: flex;
+            margin-left: 10px;
           }
           &__down{
             display: flex;
@@ -355,4 +357,40 @@
       }
     }
   }
+}
+
+.sellerSelect{
+  margin-top: 15px;
+  display: flex;
+}
+.submit-btn-gray{
+  display: block;
+    margin-top: 25px;
+    width: 60%;
+    line-height: 48px;
+    transition: all ease-out .3s;
+    font-weight: bold;
+    font-size: 18px;
+    background: #aaa;
+    border: 1px solid #aaa;
+    color: black;
+    cursor: pointer;
+    text-align: center;
+    text-decoration: none;
+    border-radius: 4px;
+}
+.submit-btn-red{
+  display: block;
+    margin: auto;
+    width: 60%;
+    line-height: 48px;
+    font-weight: bold;
+    font-size: 18px;
+    background: #ea352d;
+    border: 1px solid #ea352d;
+    color: white;
+    cursor: pointer;
+    text-align: center;
+    text-decoration: none;
+    border-radius: 4px;
 }

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -55,7 +55,10 @@
             %th
               ブランド
             %td
-              = @item.brand.name
+              - if @item.brand == nil
+                = @item.brand
+              -else
+                = @item.brand.name
           %tr
             %th
               商品の状態

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -55,7 +55,7 @@
             %th
               ブランド
             %td
-              = @item.brand
+              = @item.brand.name
           %tr
             %th
               商品の状態

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -26,7 +26,6 @@
                 %div
                   %i.far.fa-laugh
                   = rand(100)
-                  -# 評価はuser_evaluationsが入るようになる？
                 %div
                   %i.fas.far.fa-meh
                   = rand(100)
@@ -62,46 +61,41 @@
               商品の状態
             %td
               = @item.item_condition.item_condition
-              -# item_conditionかな？
           %tr
             %th
               配送料の負担
             %td
               = @item.postage_payer.postagepayer
-              -# postage_payerかな？
           %tr
             %th
               配送の方法
             %td
               = @item.postage_type.postage_type
-              -# postage_typeかな？
           %tr
             %th
               配送元地域
             %td
               = @item.prefecture.name
-              -# prefecture_codeかな？
           %tr
             %th
               発送日の目安
             %td
               = @item.preparation_day.preparation_day_name
-              -# preparation_dayかな？
     .container__item-details__price
       %span.container__item-details__price__amount
         = @item.price
-
-        
       %span.container__item-details__price__tax
         円 (税込)
       %span.container__item-details__price__delivery-fee
         送料込み
     .container__item-details__message
-      
+    - if user_signed_in? && current_user.id != @item.seller_id
       = link_to "購入画面に進む", "#", class: "container__item-details__purchase-screen-button"
-      -# -if文で商品の編集、削除できるようにする　
-        = link_to "商品の編集", edit_item_path, class: "submit-btn submit-btn-red"
-        = link_to "この商品を削除する", item_path, class: "submit-btn submit-btn-gray", method: "DELETE"
+    - elsif user_signed_in? && current_user.id == @item.seller_id
+      = link_to "商品の編集", edit_item_path, class: "submit-btn submit-btn-red"
+      = link_to "この商品を削除する", item_path, class: "submit-btn submit-btn-gray", method: "DELETE"
+    - else
+      = link_to "購入画面に進む", "/users/sign_in", class: "container__item-details__purchase-screen-button"
     .container__item-details__item-description
       %p.container__item-details__item-description__inner
         = simple_format @item.introduction
@@ -117,13 +111,6 @@
           %i.far.fa-flag
           %span
             不適切な商品の報告
-        - if @item.buyer_id != nil && current_user.id == @item.seller_id
-          .sellerSelect
-            = link_to '商品の削除', item_path(@item.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class: 'seller__delete'
-        - elsif user_signed_in? && current_user.id == @item.seller_id
-          .sellerSelect
-            = link_to '商品の編集', edit_item_path(@item.id), data:{"turbolinks" => false}, class: 'seller__edit'
-            = link_to '商品の削除', item_path(@item.id), method: :delete, data: { confirm: "本当に削除しますか？" }, class: 'seller__delete'
       .container__item-details__buttons__right
         = link_to "" do
           %i.fas.fa-lock
@@ -164,7 +151,6 @@
       %li.container__social-media__box__pinterest
         = link_to "" do
           %i.fab.fa-pinterest-square.fa-3x
-
 
   %navi.container__bread-crumbs
     %ul.container__bread-crumbs__list


### PR DESCRIPTION
# what
商品詳細ページで、指定した商品の詳細情報を確認できる様にしました。
買主（buyer_id）、売主(seller_id)、第三者(IDを持たないユーザー)で、それぞれの立場によってviewが変わる様に実装しました。

# Why
出品された商品の「詳細がわかる機能」というのは、本アプリの機能上、実装は必要不可欠でした。
購入する商品を知りたいというユーザー側の視点から、実装する必要がありました。

同じ商品でも立場によって、扱い方が変わってくるため、アプリケーションの機能上変える必要がありました。


# Note

〈売主から見た表示　（user.idは持っていて、seller.idをもつ場合）〉
https://gyazo.com/c3ccf59dfa4936c09ca9d3a51638374d

〈買主から見た表示　（user.idは持っていて、seller.idを持たない場合）〉
https://gyazo.com/21cf18a8382892d752b4c69f2f8a3c6c

〈user.idを持たない、第三者がページを訪れた場合〉
https://gyazo.com/21cf18a8382892d752b4c69f2f8a3c6c
（※viewの表示自体は買主の場合と同じだが、「購入画面に進む」を押すとリンク先がログインページに飛ぶ様に設計した）
