### PR TITLE
商品出品修正

### DIFF
--- a/app/assets/javascripts/item_new.js
+++ b/app/assets/javascripts/item_new.js
@@ -7,9 +7,7 @@ $(document).on('turbolinks:load', function(){
                       <img src="" alt="preview">
                     </div>
                     <div class="lower-box">
-                      <div class="update-box">
-                        <label class="edit_btn">編集</label>
-                      </div>
+                      
                       <div class="delete-box" id="delete_btn_${count}">
                         <span>削除</span>
                       </div>
@@ -17,6 +15,11 @@ $(document).on('turbolinks:load', function(){
                   </div>`
       return html;
     }
+    // 編集ボタン削除しました。欲しければ、したのコードをlower-box内に追加してください。
+    // <div class="update-box">
+    //   <label class="edit_btn">編集</label>
+    // </div>
+
 
     // 編集
     if (window.location.href.match(/\/items\/\d+\/edit/)){

--- a/app/assets/stylesheets/_item_new.scss
+++ b/app/assets/stylesheets/_item_new.scss
@@ -72,10 +72,10 @@
                     }
                     .delete-box {
                       color: #00b0ff;
-                      width: 50%;
+                      width: 120px;
                       height: 20px;
                       line-height: 20px;
-                      border: 1px solid #eee;
+                      // border: 1px solid #eee;
                       background: #f5f5f5;
                   
                     }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,10 +17,10 @@
  @import "reset";
  @import 'font-awesome-sprockets';
  @import 'font-awesome';
+ @import "variable";
  @import "modules/user/registrations/new";
  @import "modules/user/registrations/new_sending_destination";
  @import "modules/user/registrations/create_sending_destination";
  @import "modules/user/sessions/new";
- @import "variable";
  @import "users";
  @import "modules/flash";

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -3,7 +3,6 @@
   background: #f5f5f5;
   width: 100%;
   margin: 0 auto 0;
-  padding-top: 40px;
   &__item-details{
     width: 700px;
     height: 100%;
@@ -27,14 +26,13 @@
         max-width: 300px;
         min-height: 375px;
         width: 100%;
-        background-color: lightgray;
+        background-color: #f5f5f5;
         &__display{
           min-width: 300px;
           max-width: 300px;
           min-height: 375px;
           position: relative;
           overflow: hidden;
-          padding-top: 10px;
           &__up{
             display: flex;
           }
@@ -60,7 +58,7 @@
             th{
               width: 39%;
               text-align: left;
-              background: lightgray;
+              background: #f5f5f5;
               border: 1px solid #f5f5f5;
               padding: 8px;
               font-size: 14px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,7 +19,8 @@ class ItemsController < ApplicationController
       flash[:notice] = '出品が完了しました'
       redirect_to root_path
     else
-      redirect_to new_item_path(@item), flash: { error: @item.errors.full_messages }
+      @item.item_imgs.new
+      render :new
     end
   end
 

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -9,7 +9,7 @@
           = item.name
         %ul.body__details
           %li.body__details__price
-            = item.price
+            = convertToJPY(item.price)
             円
           %li.body__details__star
             ★0

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -25,8 +25,8 @@
                         .upper-box
                           = image_tag image.url.url, data: { index: i }, width: "112", height: '112'
                         .lower-box
-                          .update-box
-                            %label.edit-btn 編集
+                          -# .update-box
+                          -#   %label.edit-btn 編集
                           .delete-box
                             %span.js-remove 削除
                 .label-content

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -8,14 +8,7 @@
       .exhibit__main__itemProfile
         .exhibit__main__itemProfile__inputForm
         = form_with( model: @item, url: items_path, local: true) do |f|
-          - if flash[:error].present?
-            %ul.errors
-              - flash[:error].each do |e|
-                %li=e
-            .alert.alert-danger
-              %ul
-                - @item.errors.full_messages.each do |msg|
-                  %li= msg
+          = render 'layouts/error_messages', model: f.object
           .exhibit__main__itemProfile__inputForm__sellImage
             .exhibit__main__itemProfile__inputForm__sellImage__upload
               .exhibit__main__itemProfile__inputForm__sellImage__upload__head

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,3 +1,9 @@
+
+.exhibit
+  .exhibit__header
+    =link_to root_path , class: "exhibit__header__logo" do
+      =image_tag asset_path("logo.png"),class: "exhibit__header__logo__image"
+
 .container
   .container__item-details
     %h1.container__item-details__item-name


### PR DESCRIPTION
# WHAT
出品登録、出品編集で画像プレビュー箇所の編集ボタンの削除
出品登録画面のエラーハンドリングの修正。redirect_toをrenderに変更
出品詳細画面のbackground-colorの変更

# WHY
機能していないボタンがあったため
出品登録のエラーハンドリング表示が崩れていたため
色の統一のため