### PR TITLE
商品詳細ページの修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -24,9 +24,7 @@
           %tr
             %th
               出品者
-              = @item.seller.nickname
             %td
-              ニックネーム
               = @item.seller.nickname
               %div.evaluation
                 %div
@@ -65,6 +63,11 @@
                 = @item.brand
               -else
                 = @item.brand.name
+          %tr
+            %th
+              サイズ
+            %td
+              = @item.size.name
           %tr
             %th
               商品の状態


### PR DESCRIPTION
#what
商品詳細ページにて、表示の修正
（「ニックネーム」箇所、出品者表示、サイズの追加）

 # why
明らかなviewの乱れにより、訂正が必要だったため。
登録用件である、sizeの表示は必要だっため。